### PR TITLE
Add support for remote debugging oxauth inside Docker

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -39,9 +39,31 @@ prepare_jks_sync_env
 cron
 
 cd /opt/gluu/jetty/oxauth
-exec gosu root java -jar /opt/jetty/start.jar -server \
-    -Xms256m -Xmx4096m -XX:+DisableExplicitGC \
-    -Dgluu.base=/etc/gluu \
-    -Dserver.base=/opt/gluu/jetty/oxauth \
-    -Dlog.base=/opt/gluu/jetty/oxauth \
-    -Dpython.home=/opt/jython
+
+
+get_java_opts() {
+    local java_opts="
+      -server
+      -Xms256m
+      -Xmx4096m
+      -XX:+DisableExplicitGC
+      -Dgluu.base=/etc/gluu
+      -Dserver.base=/opt/gluu/jetty/oxauth
+      -Dlog.base=/opt/gluu/jetty/oxauth
+      -Dpython.home=/opt/jython
+    "
+
+    if [ -n "${GLUU_DEBUG_PORT}" ]; then
+        java_opts="
+            ${java_opts}
+            -agentlib:jdwp=transport=dt_socket,address=${GLUU_DEBUG_PORT},server=y,suspend=n
+        "
+    fi
+
+    echo "${java_opts}"
+}
+
+exec gosu \
+     root \
+     java $(get_java_opts) \
+     -jar /opt/jetty/start.jar


### PR DESCRIPTION
- Pass the environment variable GLUU_DEBUG_PORT to the docker
  container and publish it with --publish <port>.

- Default debug port is 5005.

- Ordered the JVM parameters before the call to -jar (one of the JDKs,
  can't remember which) complain about this otherwise)

- Note: the remote debugging setting is different on Oracle JDK and
  OpenJDK. This change uses the OpenJDK format as the container uses
  OpenJDK.